### PR TITLE
Updated for Spring3 (and Java 17). New version 2.0.0-SNAPSHOT to pres…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,40 +5,40 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.6</version>
+    <version>3.0.3</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>com.github.andylke</groupId>
   <artifactId>im-aop-loggers</artifactId>
-  <version>1.0.8</version>
-  
+  <version>2.0.0-SNAPSHOT</version>
+
   <name>I'm AOP Loggers</name>
   <description>A handy and configurable sets of annotation-based loggers for Spring Boot that can log every execution of a method when entering or exiting normally or abnormally, without you writing a single line of code using aspect-oriented programming (AOP)</description>
   <inceptionYear>2021</inceptionYear>
-  
+
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
-  
+
   <developers>
     <developer>
       <name>Andy Lian</name>
       <email>andylke@gmail.com</email>
     </developer>
   </developers>
-  
+
   <scm>
     <url>https://github.com/andylke/im-aop-loggers.git</url>
   </scm>
-  
+
   <properties>
-    <java.version>11</java.version>
-    <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+    <java.version>17</java.version>
+    <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
   </properties>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -52,13 +52,13 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
-  
+
     <!-- apache.commons -->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
-  
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -71,7 +71,7 @@
       </exclusions>
     </dependency>
   </dependencies>
-  
+
   <build>
     <plugins>
       <plugin>
@@ -106,7 +106,7 @@
           </execution>
         </executions>
       </plugin>
-      
+
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
@@ -145,7 +145,7 @@
           </execution>
         </executions>
       </plugin>
-      
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
@@ -167,7 +167,7 @@
           </execution>
         </executions>
       </plugin>
-      
+
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -179,10 +179,10 @@
           <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
-    
+
     </plugins>
   </build>
-  
+
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>

--- a/src/main/java/im/aop/loggers/AopLoggersAutoConfiguration.java
+++ b/src/main/java/im/aop/loggers/AopLoggersAutoConfiguration.java
@@ -1,5 +1,6 @@
 package im.aop.loggers;
 
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -10,7 +11,7 @@ import org.springframework.context.annotation.Import;
  *
  * @author Andy Lian
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnProperty(
     prefix = AopLoggersProperties.PREFIX,
     name = "enabled",

--- a/src/main/java/im/aop/loggers/AopLoggersProperties.java
+++ b/src/main/java/im/aop/loggers/AopLoggersProperties.java
@@ -1,7 +1,7 @@
 package im.aop.loggers;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;

--- a/src/main/java/im/aop/loggers/messageinterpolation/ReflectionToStringProperties.java
+++ b/src/main/java/im/aop/loggers/messageinterpolation/ReflectionToStringProperties.java
@@ -1,6 +1,6 @@
 package im.aop.loggers.messageinterpolation;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-# Auto Configure
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-im.aop.loggers.AopLoggersAutoConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+im.aop.loggers.AopLoggersAutoConfiguration


### PR DESCRIPTION
Spring 3.0.3 was current at time of writing. JUnit tests ran clean for me. Not sure how you manage your code, but bumped pom version to 2.0.0-SNAPSHOT to give you the option of maintaining a Spring 2.x branch. My IDE changed some spacing in the pom. Apologies.
I have a similar PR for your demo project.